### PR TITLE
Develop 0.0.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,3 +309,109 @@ In some cases, you might need the template variable passed into the data fetchin
 This transform supports nested vars for children (arrays and objects), but only supports 1 level of depth.
 
 It is recommended to set template vars on components that reside further down the tree and deal with those nested props directly.
+
+
+## An example showing all possible usage options (todo: move to proper documentation)
+
+```jsx
+const Person = ( { name, dob, favoriteColors, favoriteArtists, traits, showColors = true, showArtists = true, ...props } ) => {
+	const showTest = 'yes';
+	const favoriteColorsList = favoriteColors.map( ( color, index ) => {
+		return (
+			<div key={ index }>
+				{ color.label }
+			</div>
+		);
+	} );
+	return (
+		<section class="profile">
+			<h1>{ name }</h1>
+			<p>Date of birth: { dob }</p>
+			{ /* showColors && favoriteColorsList */ }
+			{ showColors && (
+				<>
+					<h2>Favorite Colors</h2>
+					<div>{ favoriteColorsList }</div>
+				</>
+			) }
+			{ showArtists && (
+				<>
+					<h2>Favorite Artists</h2>
+					<div>
+						{ favoriteArtists.map( ( artist, index ) => {
+							return (
+								<div key={ index }>
+									{ artist.name } | { artist.genre }
+								</div>
+							)
+						} ) }
+					</div>
+				</>
+			) }
+			<h2>Character traits</h2>
+			{ traits.map( ( trait, index ) => {
+				return (
+					<div>A trait: { trait }</div>
+				);
+			} ) }
+			<h2>Character traits raw</h2>
+			{ traits }
+			<h2>Combining control + replace variables</h2> 
+			{ showTest === 'yes' && name }
+			<h2>Combining control + list variables</h2> 
+			{ showTest === 'yes' && traits }
+		</section>
+	);
+}
+Person.templateVars = [
+	'name',
+	'dob',
+	[ 'showColors', { type: 'control' } ],
+	[ 'showArtists', { type: 'control' } ],
+	[ 'favoriteColors', { type: 'list', child: { type: 'object', props: [ 'value', 'label' ] } } ],
+	[ 'favoriteArtists', { type: 'list', child: { type: 'object', props: [ 'name', 'genre' ] } } ],
+	[ 'traits', { type: 'list' } ],
+	[ 'showTest', { type: 'control' } ],
+];
+```
+### This will output handlebars code
+```handlebars
+<section class="profile">
+    <h1>{{name}}</h1>
+    <p>Date of birth: {{dob}}</p>
+    {{#if_truthy showColors}}
+        <h2>Favorite Colors</h2>
+        <div>
+            {{#favoriteColors}}
+                <div>{{label}}</div>
+            {{/favoriteColors}}
+        </div>
+    {{/if_truthy}}
+    {{#if_truthy showArtists}}
+        <h2>Favorite Artists</h2>
+        <div>
+            {{#favoriteArtists}}
+                <div>{{name}} | {{genre}}</div>
+            {{/favoriteArtists}}
+        </div>
+    {{/if_truthy}}
+    <h2>Character traits</h2>
+    {{#traits}}
+        <div>A trait: {{.}}</div>
+    {{/traits}}
+    <h2>Character traits raw</h2>
+    {{#traits}}
+        {{.}}
+    {{/traits}}
+    <h2>Combining control + replace variables</h2>
+    {{#if_equal showTest "yes"}}
+        {{name}}
+    {{/if_equal}}
+    <h2>Combining control + list variables</h2>
+    {{#if_equal showTest "yes"}}
+        {{#traits}}
+            {{.}}
+        {{/traits}}
+    {{/if_equal}}
+</section>
+```

--- a/README.md
+++ b/README.md
@@ -311,7 +311,7 @@ This transform supports nested vars for children (arrays and objects), but only 
 It is recommended to set template vars on components that reside further down the tree and deal with those nested props directly.
 
 
-## An example showing all possible usage options
+## An example showing all currently possible options
 **TODO: move to proper documentation**
 
 ```jsx

--- a/README.md
+++ b/README.md
@@ -311,7 +311,8 @@ This transform supports nested vars for children (arrays and objects), but only 
 It is recommended to set template vars on components that reside further down the tree and deal with those nested props directly.
 
 
-## An example showing all possible usage options (todo: move to proper documentation)
+## An example showing all possible usage options
+**TODO: move to proper documentation)**
 
 ```jsx
 const Person = ( { name, dob, favoriteColors, favoriteArtists, traits, showColors = true, showArtists = true, ...props } ) => {

--- a/README.md
+++ b/README.md
@@ -312,7 +312,7 @@ It is recommended to set template vars on components that reside further down th
 
 
 ## An example showing all possible usage options
-**TODO: move to proper documentation)**
+**TODO: move to proper documentation**
 
 ```jsx
 const Person = ( { name, dob, favoriteColors, favoriteArtists, traits, showColors = true, showArtists = true, ...props } ) => {

--- a/README.md
+++ b/README.md
@@ -216,8 +216,8 @@ const Person = ( { name, favoriteColors } ) => {
         </>
     );
 };
-// Setup favoriteColors as type array with objects as children.
-Person.templateVars = [ 'name', [ 'favoriteColors', { type: 'array', child: { type: 'object', props: [ 'value', 'label' ] } } ] ];
+// Setup favoriteColors as type list with objects as children.
+Person.templateVars = [ 'name', [ 'favoriteColors', { type: 'list', child: { type: 'object', props: [ 'value', 'label' ] } } ] ];
 ```
 
 This will generate an array with a single value (and Handlebars tags), with an object as described by the `child` props, resulting in the following output:
@@ -229,6 +229,23 @@ This will generate an array with a single value (and Handlebars tags), with an o
         {{/favoriteColors}}
     </section>
 ```
+
+Array mapping is also supported in JSX expressions.
+
+```jsx
+const Person = ( { name, favoriteColors } ) => {
+    return (
+        <>
+            <h1>{ name }</h1>
+            { favoriteColors.map( ( color, index ) => {
+                return (
+                    <p key={ index }>A favorite color: { color.label }</p>
+                );
+            } ) }
+        </>
+    );
+};
+
 ## Exposing variables
 
 The above examples have all used variables derived from `props` passed into a component. 

--- a/index.js
+++ b/index.js
@@ -386,8 +386,8 @@ function templateVarsVisitor( { types: t, traverse, parse }, config ) {
 								if ( expressionValue ) {
 									templateExpression += ` "${ expressionValue }"`;
 								}
-								subPath.insertBefore( t.stringLiteral(`{{${ templateExpression }}}` ) );
-								subPath.insertAfter( t.stringLiteral(`{{/${ expressionOperator }}}` ) );
+								subPath.insertBefore( t.stringLiteral( `{{${ templateExpression }}}` ) );
+								subPath.insertAfter( t.stringLiteral( `{{/${ expressionOperator }}}` ) );
 
 								// Now check to see if the right of the expression is a list variable, as we need to wrap them
 								// in helper tags.

--- a/index.js
+++ b/index.js
@@ -151,7 +151,7 @@ const normaliseListVar = ( varConfig ) => {
 	return normalisedConfig;
 };
 // Build the object for the replacement var in list type vars.
-function buildListVarDeclaration( varName, varConfig, t ) {
+function buildListVarDeclaration( varName, varConfig, t, parse ) {
 	const normalisedConfig = normaliseListVar( varConfig );
 	const { type, props } = normalisedConfig.child;
 
@@ -173,6 +173,12 @@ function buildListVarDeclaration( varName, varConfig, t ) {
 	} else if ( type === 'primitive' ) {
 		// Then we're dealing with a normal array.
 		// TODO: maybe "primitive" is not the best name for this type.
+
+		const right = t.arrayExpression( [ t.stringLiteral( `{{.}}` ) ] );
+		const left = t.identifier( varName );
+		return t.variableDeclaration('let', [
+			t.variableDeclarator(left, right),
+		]);
 	}
 	return null;
 }
@@ -276,7 +282,7 @@ function templateVarsVisitor( { types: t, traverse, parse }, config ) {
 					listVars.forEach( ( templateVar, index ) => {
 						const [ varName, varConfig ] = templateVar;
 						// Alway declare as `let` so we don't need to worry about its usage later.
-						const newAssignmentExpression = buildListVarDeclaration( listVarsMap[ varName ], varConfig, t );
+						const newAssignmentExpression = buildListVarDeclaration( listVarsMap[ varName ], varConfig, t, parse );
 						if ( newAssignmentExpression ) {
 							statementPath.node.body.unshift( newAssignmentExpression );
 						}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "babel-plugin-jsx-template-vars",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "A Babel transform for rendering a Handlebars compatible pre-render of your React / Preact app for Server Side Rendering.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Adds support for a few new things:

- supports list vars and `.map()` in JSX expressions
- supports flat arrays now too using primitives
- fixes listvars + control vars (list vars were not being wrapped in template tags when used in expressions using control vars)
- adds more examples to the readme